### PR TITLE
feat/#38/[채용공고 등록,수정페이지]컴포넌트 분리 및 개발완료-추후 api 연결 및 수정예정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "next": "^15.3.0",
         "next-auth": "^4.24.11",
         "react": "^19.1.0",
+        "react-datepicker": "^8.3.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.55.0",
         "react-icons": "^5.5.0",
@@ -274,6 +275,59 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.7.tgz",
+      "integrity": "sha512-5V9pwFeiv+95Jlowq/7oiGISSrdXMTs2jfoSy8k+WM6oI/Skm1WWjPdJWeporN2O4UGcsaCJdirKffKayMoPgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.0.1",
@@ -2113,6 +2167,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2259,6 +2322,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -4980,6 +5053,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.3.0.tgz",
+      "integrity": "sha512-DhfrIJnTPJTUVRtXU7c7zooug40rD6q+Fc8UTCt19dYEotLpDQgTN98MfocY6Rc4S99oOFFEoxyanOM/TKauuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.3",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -5599,6 +5687,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "^15.3.0",
     "next-auth": "^4.24.11",
     "react": "^19.1.0",
+    "react-datepicker": "^8.3.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.5.0",

--- a/src/app/recruit/edit/page.tsx
+++ b/src/app/recruit/edit/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import RecruitForm from "../../../features/recruit/components/Form";
+
+const RecruitEditPage = () => {
+  const searchParams = useSearchParams();
+  const jobPostingId = searchParams.get("id");
+
+  if (!jobPostingId) return <p>잘못된 접근입니다.</p>;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-[#0F8C3B] mb-6">채용공고 수정</h1>
+      <RecruitForm mode="edit" jobPostingId={jobPostingId} />
+    </div>
+  );
+};
+
+export default RecruitEditPage;

--- a/src/app/recruit/new/page.tsx
+++ b/src/app/recruit/new/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import RecruitForm from "../../../features/recruit/components/Form";
+
+const NewRecruitPage = () => {
+  return (
+    <main className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6 flex justify-center items-center">채용공고 등록</h1>
+      <RecruitForm mode="new"/>
+    </main>
+  );
+};
+
+export default NewRecruitPage;

--- a/src/features/recruit/components/Agree.tsx
+++ b/src/features/recruit/components/Agree.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+
+const Agreement = () => {
+  const [agreed, setAgreed] = useState(false);
+  const [showTerms, setShowTerms] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-2 mt-4">
+      {/* 체크박스 */}
+      <div className="flex items-center">
+        <input
+          id="agreement"
+          type="checkbox"
+          checked={agreed}
+          onChange={(e) => setAgreed(e.target.checked)}
+          className={`
+          appearance-none w-4 h-4 border-2 rounded-sm
+          mr-2 transition-colors
+          ${agreed ? "bg-[#0F8C3B] border-[#0F8C3B]" : "bg-gray-100 border-gray-300"}
+        `}
+        />
+        <label
+          htmlFor="agreement"
+          className={`text-sm ${agreed ? "text-black font-medium" : "text-gray-500"}`}
+        >
+          이용약관에 동의합니다.
+        </label>
+
+        {/* 약관 보기 버튼 */}
+        <button
+          type="button"
+          onClick={() => setShowTerms(!showTerms)}
+          className="ml-1 text-sm text-[#0F8C3B] underline"
+        >
+          (약관 보기)
+        </button>
+      </div>
+
+      {/* 약관 내용 */}
+      {showTerms && (
+        <div className="text-xs border rounded-md p-3 bg-gray-50 text-gray-700 max-h-40 overflow-y-auto">
+          <p>이용약관내용들</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Agreement;

--- a/src/features/recruit/components/Career.tsx
+++ b/src/features/recruit/components/Career.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface CareerProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const Career_Type = ["경력무관", "경력"];
+
+const Career = ({ value, onChange }: CareerProps) => {
+  return (
+    <div className="flex items-center text-gray-700 ">
+      <label className="text-sm font-medium text-gray-700">경력여부</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="ml-2 w-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+      >
+        <option value=""></option>
+        {Career_Type.map((type) => (
+          <option key={type} value={type}>
+            {type}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default Career;

--- a/src/features/recruit/components/CheckWorkDay.tsx
+++ b/src/features/recruit/components/CheckWorkDay.tsx
@@ -1,0 +1,56 @@
+"use client";
+import CheckNegotiable from "./Negotiable";
+import { useState } from "react";
+
+interface WorkDayProps {
+  value: string[];
+  onChange: (value: string[]) => void;
+}
+
+const Days = ["월", "화", "수", "목", "금", "토", "일"];
+
+const CheckDays = ({ value, onChange }: WorkDayProps) => {
+  const [isNegotiable, setIsNegotiable] = useState(false);
+
+  const toggleDay = (day: string) => {
+    if (value.includes(day)) {
+      onChange(value.filter((d) => d !== day));
+    } else {
+      onChange([...value, day]);
+    }
+  };
+
+  return (
+    <div className="text-gray-700">
+      <div className="flex items-center ">
+        <label className="text-sm font-medium text-gray-700">근무 요일</label>
+        <div className="flex gap-1 flex-wrap items-center ml-2">
+          {Days.map((day) => (
+            <button
+              type="button"
+              key={day}
+              onClick={() => toggleDay(day)}
+              className={`px-2 py-1 border rounded-md text-sm ${
+                value.includes(day)
+                  ? "bg-[#0F8C3B] text-white"
+                  : "bg-white text-gray-700 border-gray-300"
+              }`}
+            >
+              {day}
+            </button>
+          ))}
+        </div>
+        </div>
+        <div className="mt-1 ml-14">
+          {/* 드롭다운 정렬 맞추기 위해 label 너비만큼 왼쪽 여백 */}
+          <CheckNegotiable
+            id="workTimeNegotiable"
+            checked={isNegotiable}
+            onChange={setIsNegotiable}
+          />
+        </div>
+    </div>
+  );
+};
+
+export default CheckDays;

--- a/src/features/recruit/components/Deadline.tsx
+++ b/src/features/recruit/components/Deadline.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import { ko } from "date-fns/locale";
+
+interface DeadlineProps {
+  value: Date | null;
+  onChange: (date: Date | null) => void;
+}
+
+const Deadline = ({ value, onChange }: DeadlineProps) => {
+  return (
+    <div className="flex items-center gap-1 text-gray-700">
+      {/* 라벨 */}
+      <label className="text-sm font-medium text-gray-700">공고 마감일</label>
+
+      {/* 날짜 선택기 */}
+      <DatePicker
+        selected={value}
+        onChange={(date: Date | null) => onChange(date)}
+        dateFormat="yyyy-MM-dd"
+        placeholderText="공고마감일 선택"
+        minDate={new Date()}
+        locale={ko}
+        className="ml-2 w-50 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B]"
+      />
+    </div>
+  );
+};
+
+export default Deadline;

--- a/src/features/recruit/components/DelModal.tsx
+++ b/src/features/recruit/components/DelModal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface DeleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+const DeleteModal = ({ isOpen, onClose, onDelete }: DeleteModalProps) => {
+  // body 스크롤 막기
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
+    }
+
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+      <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-sm">
+        <p className="text-lg font-bold text-gray-900 mb-2">
+          삭제된 공고는 복수할 수 없습니다.
+        </p>
+        <p className="text-sm text-gray-600 mb-6">
+          정말로 삭제하시겠습니까?
+        </p>
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
+          >
+            닫기
+          </button>
+          <button
+            onClick={onDelete}
+            className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+          >
+            삭제하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteModal;

--- a/src/features/recruit/components/Education.tsx
+++ b/src/features/recruit/components/Education.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface EducationProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const Education_Type = ["고졸", "대졸", "무관"];
+
+const Education = ({ value, onChange }: EducationProps) => {
+  return (
+    <div className="flex items-center text-gray-700 ">
+      <label className="text-sm font-medium text-gray-700">경력여부</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="ml-2 w-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+      >
+        <option value=""></option>
+        {Education_Type.map((type) => (
+          <option key={type} value={type}>
+            {type}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default Education;

--- a/src/features/recruit/components/Employee.tsx
+++ b/src/features/recruit/components/Employee.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface EmployeeProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const Employee_Type = ["정규직", "계약직"];
+
+const Employee = ({ value, onChange }: EmployeeProps) => {
+  return (
+    <div className="flex items-center text-gray-700 ">
+      <label className="text-sm font-medium text-gray-700">고용 형태</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="ml-3 w-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+      >
+        <option value=""></option>
+        {Employee_Type.map((type) => (
+          <option key={type} value={type}>
+            {type}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default Employee;

--- a/src/features/recruit/components/Form.tsx
+++ b/src/features/recruit/components/Form.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import FormTitle from "./FormTitle";
+import InputPlace from "./WorkPlace";
+import CheckDays from "./CheckWorkDay";
+import WorkTime from "./WorkTime";
+import PayType from "./Pay";
+import TextArea from "./TextArea";
+import Summary from "./Summary";
+import Employee from "./Employee";
+import Career from "./Career";
+import Education from "./Education";
+import Volume from "./Volume";
+import Deadline from "./Deadline";
+import Agreement from "./Agree";
+import SelectJobs from "./JobCategories";
+import SubmitButton from "./SubmitButton";
+import DeleteModal from "./DelModal";
+
+interface RecruitFormProps {
+  mode: "new" | "edit";
+  jobPostingId?: string;
+}
+
+const RecruitForm = ({ mode, jobPostingId }: RecruitFormProps) => {
+  const [title, setTitle] = useState("");
+  const [workPlace, setWorkPlace] = useState("");
+  const [workDays, setWorkDays] = useState<string[]>([]);
+  const [workStartTime, setWorkStartTime] = useState("");
+  const [workEndTime, setWorkEndTime] = useState("");
+  const [workTimeNegotiable, setWorkTimeNegotiable] = useState(false);
+  const [payType, setPayType] = useState("");
+  const [textArea, setTextArea] = useState("");
+  const [summary, setSummary] = useState("");
+  const [employee, setEmployee] = useState("");
+  const [career, setCareer] = useState("");
+  const [education, setEducation] = useState("");
+  const [volume, setVolume] = useState("");
+  const [deadline, setDeadline] = useState<Date | null>(null);
+  const [selectJobs, setSelectJobs] = useState<string[]>([]);
+
+  const [showDelModal, setShowDelModal] = useState(false);
+
+  useEffect(() => {
+    if (mode === "edit") {
+    }
+  }, [mode]);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const formData = {
+      공고제목: title,
+      근무지: workPlace,
+      근무요일: workDays,
+      근무시간: workTimeNegotiable ? "협의 가능" : `${workStartTime} ~ ${workEndTime}`,
+      급여형태: payType,
+      상세내용: textArea,
+      요약내용: summary,
+      고용형태: employee,
+      경력: career,
+      학력: education,
+      모집인원: volume,
+      마감일: deadline,
+      직종: selectJobs,
+    };
+
+    if (mode === "new") {
+      console.log("신규공고등록:", formData);
+    } else {
+      console.log("공고수정:", formData);
+    }
+  };
+  const handleDelete = () => {
+    console.log("공고 삭제 요청");
+    setShowDelModal(false);
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <FormTitle value={title} onChange={setTitle} />
+        </div>
+
+        <div className="mt-5">
+          <label className="text-lg text-[#0F8C3B] font-bold">
+            공고 기본 정보
+          </label>
+
+          <div className="mt-5">
+            <InputPlace value={workPlace} onChange={setWorkPlace} />
+          </div>
+
+          <div className="mt-2 flex items-center justify-between">
+            <PayType value={payType} onChange={setPayType} />
+            <Employee value={employee} onChange={setEmployee} />
+          </div>
+
+          <div className="mt-2 flex items-center justify-between">
+            <Career value={career} onChange={setCareer} />
+            <Education value={education} onChange={setEducation} />
+          </div>
+
+          <div className="mt-2">
+            <SelectJobs value={selectJobs} onChange={setSelectJobs} />
+          </div>
+
+          <div className="mt-2 flex items-center justify-between">
+            <WorkTime
+              valueStart={workStartTime}
+              valueEnd={workEndTime}
+              negotiable={workTimeNegotiable}
+              onChangeStart={setWorkStartTime}
+              onChangeEnd={setWorkEndTime}
+              onChangeNegotiable={setWorkTimeNegotiable}
+            />
+            <CheckDays value={workDays} onChange={setWorkDays} />
+          </div>
+
+          <div className="mt-2 flex items-center justify-between">
+            <Volume value={volume} onChange={setVolume} />
+            <Deadline value={deadline} onChange={setDeadline} />
+          </div>
+
+          <div>
+            <Summary value={summary} onChange={setSummary} />
+          </div>
+
+          <div className="mt-5">
+            <TextArea value={textArea} onChange={setTextArea} />
+          </div>
+
+          <Agreement />
+
+          <div className="mt-5 flex justify-between items-center">
+            {mode === "edit" && (
+              <button
+                type="button"
+                onClick={() => setShowDelModal(true)}
+                className="text-sm text-red-500 underline hover:text-red-700"
+              >
+                공고 삭제하기
+              </button>
+            )}
+            <SubmitButton
+              disabled={
+                !title ||
+                !workPlace ||
+                !workDays.length ||
+                (!workTimeNegotiable && (!workStartTime || !workEndTime)) ||
+                !payType ||
+                !textArea ||
+                !summary ||
+                !employee ||
+                !career ||
+                !education ||
+                !volume ||
+                !deadline ||
+                !selectJobs.length
+              } mode={mode}
+            />
+          </div>
+        </div>
+      </form>
+
+      <DeleteModal
+        isOpen={showDelModal}
+        onClose={() => setShowDelModal(false)}
+        onDelete={handleDelete}
+      />
+    </div>
+  );
+};
+
+export default RecruitForm;

--- a/src/features/recruit/components/FormTitle.tsx
+++ b/src/features/recruit/components/FormTitle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface RecruitFormTitleProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const FormTitle = ({ value, onChange }: RecruitFormTitleProps) => {
+  return (
+    <div className="flex flex-col space-y-1">
+      <label className="text-lg text-[#0F8C3B] font-bold">공고 제목</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="공고 제목을 입력해주세요."
+        className="mt-2 w-full border border-gray-300 rounded-md px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+      />
+    </div>
+  );
+};
+
+export default FormTitle;

--- a/src/features/recruit/components/JobCategories.tsx
+++ b/src/features/recruit/components/JobCategories.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+interface JobProps {
+  value: string[];
+  onChange: (value: string[]) => void;
+}
+
+const JobList = ["서비스", "운반", "청소", "배달", "인바운드", "경비", "고객상담"];
+
+const SelectJobs = ({ value, onChange }: JobProps) => {
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const toggleCategory = (category: string) => {
+    if (value.includes(category)) {
+      onChange(value.filter((item) => item !== category));
+    } else {
+      onChange([...value, category]);
+    }
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="flex justify-between items-center text-gray-700 relative" ref={dropdownRef}>
+      {/* 왼쪽: 레이블 */}
+      <label className="text-sm font-medium text-gray-700 whitespace-nowrap">직종</label>
+
+      {/* 오른쪽: 드롭다운 버튼 */}
+      <div className="ml-8 w-full relative">
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className="w-full text-left px-3 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-[#0F8C3B]"
+        >
+          <span className={value.length === 0 ? "text-gray-400" : "text-gray-700"}>
+            {value.length === 0 ? "직종을 선택하세요" : value.join(", ")}
+          </span>
+        </button>
+
+        {/* 드롭다운 목록 */}
+        {open && (
+          <div className="absolute z-10 w-full mt-1 border border-gray-300 bg-white rounded-md shadow-md max-h-48 overflow-auto">
+            {JobList.map((job) => (
+              <label
+                key={job}
+                className="flex items-center px-3 py-2 text-sm cursor-pointer hover:bg-gray-100"
+              >
+                <input
+                  type="checkbox"
+                  className="mr-2"
+                  checked={value.includes(job)}
+                  onChange={() => toggleCategory(job)}
+                />
+                {job}
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SelectJobs;

--- a/src/features/recruit/components/Negotiable.tsx
+++ b/src/features/recruit/components/Negotiable.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+
+interface CheckNegotiableProps {
+  id: string; // 체크박스 ID (여러 곳에서 쓸 수 있도록 분리)
+  checked: boolean; // 현재 체크 여부 (form에서 상태 관리용)
+  onChange: (checked: boolean) => void; // 체크 시 실행할 함수
+}
+
+const CheckNegotiable = ({ id, checked, onChange }: CheckNegotiableProps) => {
+  return (
+    <div className="flex items-center">
+      {/* 체크박스 */}
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className={`
+          appearance-none w-4 h-4 border-2 rounded-sm
+          mr-2 transition-colors
+          ${checked ? "bg-[#0F8C3B] border-[#0F8C3B]" : "bg-gray-100 border-gray-300"}
+        `}
+      />
+
+      {/* 체크박스 라벨 */}
+      <label
+        htmlFor={id}
+        className={`text-sm transition-colors ${checked ? "text-black font-medium" : "text-gray-500"}`}
+      >
+        협의 가능
+      </label>
+    </div>
+  );
+};
+
+export default CheckNegotiable;

--- a/src/features/recruit/components/Pay.tsx
+++ b/src/features/recruit/components/Pay.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useState } from "react";
+import InputPay from "./PayAmount";
+
+interface PayTypeProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const Pay_Type = ["시급", "일급", "월급"];
+
+const PayType = ({ value, onChange }: PayTypeProps) => {
+  const [payInput, setPayInput] = useState("");
+
+  return (
+    <div className="flex items-center text-gray-700 ">
+      <label className="text-sm font-medium text-gray-700">급여</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="ml-8 m-1 w-18 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+      >
+        <option value=""></option>
+        {Pay_Type.map((type) => (
+          <option key={type} value={type}>
+            {type}
+          </option>
+        ))}
+      </select>
+      <InputPay value={payInput} onChange={setPayInput} />
+    </div>
+  );
+};
+
+export default PayType;

--- a/src/features/recruit/components/PayAmount.tsx
+++ b/src/features/recruit/components/PayAmount.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+interface InputPayProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const InputPay = ({ value, onChange }: InputPayProps) => {
+  return (
+    <div className="flex relative">
+      <input
+        type="string"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="예)1,000,000"
+        className="pr-6 w-40 m-1 border border-gray-300 rounded-md px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+      ></input>
+      <span className="absolute top-1/2 right-3 transform -translate-y-1/2 text-sm text-gray-700 pointer-events-none">
+        원
+      </span>
+    </div>
+  );
+};
+
+export default InputPay;

--- a/src/features/recruit/components/PayAmount.tsx
+++ b/src/features/recruit/components/PayAmount.tsx
@@ -1,20 +1,33 @@
 "use client";
 
 interface InputPayProps {
-  value: string;
-  onChange: (value: string) => void;
+  value: string; // 예: "1000000"
+  onChange: (value: string) => void; // 콤마 없는 숫자만 전달
 }
 
+// 천 단위 콤마 붙이는 함수
+const formatWithComma = (value: string) => {
+  if (!value) return "";
+  const number = value.replace(/[^0-9]/g, "");
+  return number.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};
+
 const InputPay = ({ value, onChange }: InputPayProps) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value.replace(/[^0-9]/g, "");
+    onChange(input);
+  };
+
   return (
     <div className="flex relative">
       <input
-        type="string"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="예)1,000,000"
+        type="text"
+        inputMode="numeric"
+        value={formatWithComma(value)}
+        onChange={handleChange}
+        placeholder="예) 1,000,000"
         className="pr-6 w-40 m-1 border border-gray-300 rounded-md px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
-      ></input>
+      />
       <span className="absolute top-1/2 right-3 transform -translate-y-1/2 text-sm text-gray-700 pointer-events-none">
         원
       </span>

--- a/src/features/recruit/components/SubmitButton.tsx
+++ b/src/features/recruit/components/SubmitButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+// 🧾 props 타입 정의
+interface SubmitProps {
+  disabled: boolean;
+  mode: "new" | "edit"; // 등록 or 수정 구분
+}
+
+// 📦 버튼 컴포넌트
+const SubmitButton = ({ disabled, mode }: SubmitProps) => {
+  return (
+    <button
+      type="submit"
+      className={`w-full py-2 rounded-md text-sm transition-colors ${
+        disabled
+          ? "bg-gray-300 text-white cursor-not-allowed"
+          : "bg-[#0F8C3B] text-white hover:bg-[#0e7b33]"
+      }`}
+      disabled={disabled}
+    >
+      {mode === "new" ? "채용공고 수정" : "채용공고 등록"}
+    </button>
+  );
+};
+
+export default SubmitButton;
+

--- a/src/features/recruit/components/Summary.tsx
+++ b/src/features/recruit/components/Summary.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface SummaryProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const Summary = ({ value, onChange }: SummaryProps) => {
+  return (
+    <div className="mt-2 flex justify-between items-center">
+      <label className="text-sm font-medium text-gray-700 whitespace-nowrap">근무요약</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="50자 이내로 입력해주세요."
+        className="ml-2 w-full border text-gray-700 border-gray-300 rounded-md px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#0F8C3B]"
+      />
+    </div>
+  );
+};
+
+export default Summary;

--- a/src/features/recruit/components/TextArea.tsx
+++ b/src/features/recruit/components/TextArea.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+interface TextProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const TextArea = ({ value, onChange }: TextProps) => {
+  return (
+    <div>
+      <label className="text-lg text-[#0F8C3B] font-bold">상세 요강</label>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="공고 상세 내용을 작성해주세요."
+        className="mt-2 h-100 w-full border text-gray-700 border-gray-300 rounded-md px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+      />
+    </div>
+  );
+};
+export default TextArea

--- a/src/features/recruit/components/Volume.tsx
+++ b/src/features/recruit/components/Volume.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+interface VolumeProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const Volume = ({ value, onChange }: VolumeProps) => {
+  return (
+    <div className="flex items-center text-gray-700 ">
+      <label className="text-sm font-medium text-gray-700">모집인원</label>
+      <div className="flex relative">
+        <input
+          type="string"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="숫자만 입력해주세요."
+          className="ml-2 m-1 pr-6 w-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+        ></input>
+        <span className="absolute top-1/2 right-3 transform -translate-y-1/2 text-sm text-gray-700 pointer-events-none">
+          명
+        </span>
+      </div>
+    </div> 
+  );
+};
+
+export default Volume;

--- a/src/features/recruit/components/Volume.tsx
+++ b/src/features/recruit/components/Volume.tsx
@@ -1,28 +1,35 @@
 "use client";
 
 interface VolumeProps {
-  value: string;
+  value: string; // 숫자 문자열 (예: "3", "00")
   onChange: (value: string) => void;
 }
 
 const Volume = ({ value, onChange }: VolumeProps) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const onlyNums = e.target.value.replace(/[^0-9]/g, ""); // 숫자만 허용
+    onChange(onlyNums);
+  };
+
   return (
-    <div className="flex items-center text-gray-700 ">
+    <div className="flex items-center text-gray-700">
       <label className="text-sm font-medium text-gray-700">모집인원</label>
       <div className="flex relative">
         <input
-          type="string"
+          type="text"
+          inputMode="numeric"
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={handleChange}
           placeholder="숫자만 입력해주세요."
           className="ml-2 m-1 pr-6 w-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
-        ></input>
+        />
         <span className="absolute top-1/2 right-3 transform -translate-y-1/2 text-sm text-gray-700 pointer-events-none">
           명
         </span>
       </div>
-    </div> 
+    </div>
   );
 };
 
 export default Volume;
+

--- a/src/features/recruit/components/WorkPlace.tsx
+++ b/src/features/recruit/components/WorkPlace.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface PlaceProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const InputPlace = ({ value, onChange }: PlaceProps) => {
+  return (
+    <div className="flex justify-between items-center">
+      <label className="text-sm font-medium text-gray-700 whitespace-nowrap">근무지</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="근무지를 입력해주세요."
+        className="ml-5 w-full border text-gray-700 border-gray-300 rounded-md px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#0F8C3B]"
+      />
+    </div>
+  );
+};
+
+export default InputPlace;

--- a/src/features/recruit/components/WorkTime.tsx
+++ b/src/features/recruit/components/WorkTime.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import CheckNegotiable from "./Negotiable";
+
+// 🔧 컴포넌트에서 사용할 props 타입 정의
+interface WorkTimeProps {
+  valueStart: string;
+  valueEnd: string;
+  negotiable: boolean;
+  onChangeStart: (value: string) => void;
+  onChangeEnd: (value: string) => void;
+  onChangeNegotiable: (value: boolean) => void;
+}
+
+// ⏰ 30분 단위 시간 배열 생성
+const timeOptions = Array.from({ length: 48 }, (_, index) => {
+  const hour = String(Math.floor(index / 2)).padStart(2, "0");
+  const minute = index % 2 === 0 ? "00" : "30";
+  return `${hour}:${minute}`;
+});
+
+// 📦 props 기반의 근무시간 컴포넌트
+export default function WorkTime({
+  valueStart,
+  valueEnd,
+  negotiable,
+  onChangeStart,
+  onChangeEnd,
+  onChangeNegotiable,
+}: WorkTimeProps) {
+  return (
+    <div className="text-gray-700">
+      <div className="flex items-center">
+        <label className="text-sm font-medium text-gray-700">근무 시간</label>
+
+        {/* 시간 선택 드롭다운 */}
+        <div className="flex items-center gap-1">
+          {/* 시작 시간 */}
+          <select
+            className="ml-1 w-28 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B]"
+            value={valueStart}
+            onChange={(e) => onChangeStart(e.target.value)}
+            disabled={negotiable} // 협의 가능 시 비활성화
+          >
+            <option value="">시작 시간</option>
+            {timeOptions.map((time) => (
+              <option key={time} value={time}>
+                {time}
+              </option>
+            ))}
+          </select>
+
+          <span className="text-sm font-medium">~</span>
+
+          {/* 종료 시간 */}
+          <select
+            className="w-28 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B]"
+            value={valueEnd}
+            onChange={(e) => onChangeEnd(e.target.value)}
+            disabled={negotiable} // 협의 가능 시 비활성화
+          >
+            <option value="">종료 시간</option>
+            {timeOptions.map((time) => (
+              <option key={time} value={time}>
+                {time}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* 하단 체크박스 */}
+      <div className="mt-1 ml-14">
+        <CheckNegotiable
+          id="workTimeNegotiable"
+          checked={negotiable}
+          onChange={onChangeNegotiable}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#38

## 📝작업 내용
채용공고 등록 및 수정 페이지를 컴포넌트 분리하여 작업하였습니다.
약관보기 버튼을 누르면 약관의 내용이 펼쳐져서 볼수있고 입력값을 전부 입력해야지만 등록하기 버튼이 활성화가 됩니다.


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


### 스크린샷 (선택)
<img width="676" alt="스크린샷 2025-04-15 오후 4 33 35" src="https://github.com/user-attachments/assets/5a9d115c-bfc3-409b-9382-aab5f5131d00" />
<img width="705" alt="스크린샷 2025-04-15 오후 4 33 51" src="https://github.com/user-attachments/assets/369eb2e3-fc41-4944-bee3-c910dcc016af" />
<img width="677" alt="스크린샷 2025-04-15 오후 4 39 33" src="https://github.com/user-attachments/assets/00fe1adc-30a5-44b3-be72-dcdf279768c7" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
