### PR TITLE
feat/#38/[채용공고 등록 수정페이지]문구 및 요소 화면 정렬

### DIFF
--- a/src/features/recruit/components/Education.tsx
+++ b/src/features/recruit/components/Education.tsx
@@ -10,11 +10,11 @@ const Education_Type = ["고졸", "대졸", "무관"];
 const Education = ({ value, onChange }: EducationProps) => {
   return (
     <div className="flex items-center text-gray-700 ">
-      <label className="text-sm font-medium text-gray-700">경력여부</label>
+      <label className="text-sm font-medium text-gray-700">학력</label>
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="ml-2 w-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+        className="ml-10 w-50 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
       >
         <option value=""></option>
         {Education_Type.map((type) => (

--- a/src/features/recruit/components/Form.tsx
+++ b/src/features/recruit/components/Form.tsx
@@ -86,9 +86,7 @@ const RecruitForm = ({ mode, jobPostingId }: RecruitFormProps) => {
         </div>
 
         <div className="mt-5">
-          <label className="text-lg text-[#0F8C3B] font-bold">
-            공고 기본 정보
-          </label>
+          <label className="text-lg text-[#0F8C3B] font-bold">공고 기본 정보</label>
 
           <div className="mt-5">
             <InputPlace value={workPlace} onChange={setWorkPlace} />
@@ -152,7 +150,6 @@ const RecruitForm = ({ mode, jobPostingId }: RecruitFormProps) => {
                 !workDays.length ||
                 (!workTimeNegotiable && (!workStartTime || !workEndTime)) ||
                 !payType ||
-                !textArea ||
                 !summary ||
                 !employee ||
                 !career ||
@@ -160,7 +157,8 @@ const RecruitForm = ({ mode, jobPostingId }: RecruitFormProps) => {
                 !volume ||
                 !deadline ||
                 !selectJobs.length
-              } mode={mode}
+              }
+              mode={mode}
             />
           </div>
         </div>

--- a/src/features/recruit/components/Pay.tsx
+++ b/src/features/recruit/components/Pay.tsx
@@ -18,7 +18,7 @@ const PayType = ({ value, onChange }: PayTypeProps) => {
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="ml-8 m-1 w-18 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent"
+        className="ml-8 m-1 w-18 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#0F8C3B] focus:border-transparent "
       >
         <option value=""></option>
         {Pay_Type.map((type) => (

--- a/src/features/recruit/components/SubmitButton.tsx
+++ b/src/features/recruit/components/SubmitButton.tsx
@@ -18,10 +18,9 @@ const SubmitButton = ({ disabled, mode }: SubmitProps) => {
       }`}
       disabled={disabled}
     >
-      {mode === "new" ? "채용공고 수정" : "채용공고 등록"}
+      {mode === "new" ? "채용공고 등록" : "채용공고 수정"}
     </button>
   );
 };
 
 export default SubmitButton;
-


### PR DESCRIPTION
## #️⃣연관된 이슈
#38 

## 📝작업 내용
텍스트에 오타가 있어 수정하고 요소들을 화면에 정렬되도록 하였습니다.


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="729" alt="스크린샷 2025-04-15 오후 5 09 42" src="https://github.com/user-attachments/assets/8308a9ab-3390-4a04-b5e3-9929d42739a1" />
<img width="671" alt="스크린샷 2025-04-15 오후 5 09 50" src="https://github.com/user-attachments/assets/b259f772-d0a4-4c98-ae38-b3a5689c7457" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
