### PR TITLE
feat/#95/[마이페이지 이력서 탭] 이력서 리스트 컴포넌트

### DIFF
--- a/src/features/mypage/common/components/profile/ProfileCard.tsx
+++ b/src/features/mypage/common/components/profile/ProfileCard.tsx
@@ -48,7 +48,7 @@ export default function ProfileCard({ role, title, items }: ProfileCardProps) {
 
   return (
     <div className="w-[calc(100%-2rem)] sm:w-[36rem] md:w-[48rem] lg:w-[64rem] mx-auto bg-white rounded-2xl shadow-sm overflow-hidden">
-      <div className="flex items-center justify-between p-4 sm:p-6 border-b">
+      <div className="flex items-center justify-between p-4 border-b sm:p-6">
         <Heading sizeOffset={4} className="font-bold text-gray-900 break-all">
           {displayTitle}
         </Heading>
@@ -56,21 +56,21 @@ export default function ProfileCard({ role, title, items }: ProfileCardProps) {
           onClick={handleEditClick}
           className="bg-primary hover:bg-primary/90 text-white px-3 sm:px-4 md:px-5 py-1.5 md:py-2 rounded-lg transition-colors duration-200 font-medium flex items-center gap-2 shadow-sm shrink-0 ml-3 sm:ml-4"
         >
-          <PenSquare className="h-4 w-4" />
-          <Heading sizeOffset={2} className="hidden sm:inline text-white">
+          <PenSquare className="w-5 h-5" />
+          <Heading sizeOffset={2} className="hidden text-white sm:inline">
             정보 수정
           </Heading>
-          <Heading sizeOffset={2} className="sm:hidden text-white">
+          <Heading sizeOffset={2} className="text-white sm:hidden">
             수정
           </Heading>
         </button>
       </div>
-      <div className="bg-gray-50/50 rounded-xl m-3 sm:m-4 md:m-5 p-3 sm:p-4 md:p-5 break-words">
+      <div className="p-3 m-3 break-words bg-gray-50/50 rounded-xl sm:m-4 md:m-5 sm:p-4 md:p-5">
         <div className="space-y-5">
           {items.map((item, index) => (
             <div
               key={index}
-              className="flex items-center py-3 hover:bg-white/80 transition-colors rounded-lg px-4 group"
+              className="flex items-center px-4 py-3 transition-colors rounded-lg hover:bg-white/80 group"
             >
               <ProfileLabel labels={item.labels} isEmployer={role === "company"} />
               {item.isCustom ? (

--- a/src/features/mypage/common/components/profile/UserProfile.tsx
+++ b/src/features/mypage/common/components/profile/UserProfile.tsx
@@ -53,6 +53,26 @@ export default function UserProfile(props: UserProfileProps) {
       created_at: "2024-03-01T09:00:00.000Z",
       updated_at: "2024-03-01T09:00:00.000Z",
     },
+    {
+      resume_id: "4",
+      user_id: "123",
+      resume_title: "성실한 직원이 되겠습니다",
+      job_category: "패스트푸드점",
+      education: "대학교 재학",
+      introduce: "책임감 있게 일하겠습니다.",
+      created_at: "2024-03-01T09:00:00.000Z",
+      updated_at: "2024-03-01T09:00:00.000Z",
+    },
+    // {
+    //   resume_id: "5",
+    //   user_id: "123",
+    //   resume_title: "제과제빵 경력 2년",
+    //   job_category: "제과제빵",
+    //   education: "제과제빵 전문학교",
+    //   introduce: "맛있는 빵을 만들고 싶습니다.",
+    //   created_at: "2024-03-01T09:00:00.000Z",
+    //   updated_at: "2024-03-01T09:00:00.000Z",
+    // },
   ];
 
   const { name, phone_number, birthday, interest } = userProfileData;

--- a/src/features/mypage/common/components/profile/UserProfile.tsx
+++ b/src/features/mypage/common/components/profile/UserProfile.tsx
@@ -2,7 +2,9 @@ import React, { useMemo } from "react";
 import ProfileCard, { ProfileItem } from "./ProfileCard";
 import UserProfileTabs from "./UserProfileTabs";
 import { Heading } from "@/components/ui/Heading";
+import { formatBirthDate } from "@/utils/format";
 import { UserProfile as UserProfileType } from "@/types/user";
+import type { Resume } from "@/types/resume";
 
 interface UserProfileProps {}
 
@@ -19,12 +21,46 @@ export default function UserProfile(props: UserProfileProps) {
     updated_at: new Date().toISOString(),
   };
 
+  // 이력서 더미 데이터
+  const dummyResumes: Resume[] = [
+    {
+      resume_id: "1",
+      user_id: "123",
+      resume_title: "신입 바리스타 지원합니다",
+      job_category: "바리스타",
+      education: "고등학교 졸업",
+      introduce: "열정적인 바리스타가 되고 싶습니다.",
+      created_at: "2024-01-15T09:00:00.000Z",
+      updated_at: "2024-01-15T09:00:00.000Z",
+    },
+    {
+      resume_id: "2",
+      user_id: "123",
+      resume_title: "제과제빵 경력 2년",
+      job_category: "제과제빵",
+      education: "제과제빵 전문학교",
+      introduce: "맛있는 빵을 만들고 싶습니다.",
+      created_at: "2024-02-01T09:00:00.000Z",
+      updated_at: "2024-02-10T15:00:00.000Z",
+    },
+    {
+      resume_id: "3",
+      user_id: "123",
+      resume_title: "성실한 직원이 되겠습니다",
+      job_category: "패스트푸드점",
+      education: "대학교 재학",
+      introduce: "책임감 있게 일하겠습니다.",
+      created_at: "2024-03-01T09:00:00.000Z",
+      updated_at: "2024-03-01T09:00:00.000Z",
+    },
+  ];
+
   const { name, phone_number, birthday, interest } = userProfileData;
 
   const profileItems: ProfileItem[] = useMemo(
     () => [
       { labels: ["전화번호"], value: phone_number },
-      { labels: ["생년월일"], value: birthday },
+      { labels: ["생년월일"], value: formatBirthDate(birthday) },
       {
         labels: ["관심분야"],
         value: interest?.length ? (
@@ -51,7 +87,7 @@ export default function UserProfile(props: UserProfileProps) {
   return (
     <div>
       <ProfileCard role="user" title={name} items={profileItems} />
-      <UserProfileTabs resumes={null} appliedJobs={null} savedJobs={null} />
+      <UserProfileTabs resumes={dummyResumes} appliedJobs={null} savedJobs={null} />
     </div>
   );
 }

--- a/src/features/mypage/common/components/profile/UserProfileTabs.tsx
+++ b/src/features/mypage/common/components/profile/UserProfileTabs.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import { Heading } from "@/components/ui/Heading";
+import ResumeList from "../resume/ResumeList";
+import type { Resume } from "@/types/resume";
 
 interface EmptyContentProps {
   title: string;
@@ -18,7 +20,7 @@ const EmptyContent = ({ title, message }: EmptyContentProps) => (
 );
 
 interface UserProfileTabsProps {
-  resumes: React.ReactNode;
+  resumes: Resume[] | null;
   appliedJobs: React.ReactNode;
   savedJobs: React.ReactNode;
 }
@@ -41,7 +43,7 @@ export default function UserProfileTabs({ resumes, appliedJobs, savedJobs }: Use
   const getTabContent = (tab: TabType) => {
     switch (tab) {
       case "resumes":
-        return <EmptyContent title="내 이력서 목록" message="아직 작성된 이력서가 없습니다." />;
+        return <ResumeList resumes={resumes} />;
       case "applied":
         return <EmptyContent title="지원한 공고 목록" message="아직 지원한 공고가 없습니다." />;
       case "saved":
@@ -66,7 +68,7 @@ export default function UserProfileTabs({ resumes, appliedJobs, savedJobs }: Use
           ))}
         </div>
       </div>
-      <div className="py-6 break-words">{getTabContent(activeTab)}</div>
+      <div className="py-6">{getTabContent(activeTab)}</div>
     </div>
   );
 }

--- a/src/features/mypage/common/components/resume/ResumeList.tsx
+++ b/src/features/mypage/common/components/resume/ResumeList.tsx
@@ -27,16 +27,21 @@ export default function ResumeList({ resumes }: ResumeListProps) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between p-4 sm:p-6">
-        <Heading sizeOffset={3} className="font-bold text-gray-900">
+      <div className="flex items-center justify-between pt-4 sm:pt-6">
+        <Heading sizeOffset={3} className="pl-3 font-bold text-gray-900">
           이력서 목록
         </Heading>
         <button
           onClick={handleAddResume}
-          className="bg-primary hover:bg-primary/90 text-white px-4 py-2 rounded-lg transition-all duration-200 font-medium flex items-center gap-2 hover:shadow-md"
+          className="flex items-center gap-2 px-4 py-2 font-medium text-white transition-all duration-200 rounded-lg bg-primary hover:bg-primary/90 hover:shadow-md"
         >
-          <Plus className="h-5 w-5" />
-          <span>이력서 추가</span>
+          <Plus className="w-5 h-5" />
+          <Heading sizeOffset={2} className="hidden sm:inline">
+            이력서 추가
+          </Heading>
+          <Heading sizeOffset={2} className="sm:hidden">
+            추가
+          </Heading>
         </button>
       </div>
 
@@ -45,32 +50,32 @@ export default function ResumeList({ resumes }: ResumeListProps) {
           <button
             key={resume.resume_id}
             onClick={() => handleResumeClick(resume.resume_id)}
-            className="w-full bg-white hover:bg-gray-50/80 border border-gray-100 rounded-xl p-4 transition-all duration-200 group hover:shadow-md"
+            className="w-full p-4 transition-all duration-200 bg-white border border-gray-100 hover:bg-gray-50/80 rounded-xl group hover:shadow-md"
           >
             <div className="flex items-center justify-between">
               <div className="flex flex-col gap-2">
-                <Heading sizeOffset={2} className="font-semibold text-gray-900 text-left">
+                <Heading sizeOffset={2} className="font-semibold text-left text-gray-900">
                   {resume.resume_title}
                 </Heading>
-                <div className="flex items-center gap-2">
-                  <span className="bg-primary/5 text-primary px-3 py-1 rounded-full font-medium">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                  <div className="inline-block px-3 py-1 font-medium rounded-full bg-primary/5 text-primary whitespace-nowrap">
                     {resume.job_category}
-                  </span>
-                  <span className="text-gray-500 text-sm">
+                  </div>
+                  <div className="mt-1.5 sm:mt-0 text-gray-500">
                     최종 수정 : {formatDate(resume.updated_at)}
-                  </span>
+                  </div>
                 </div>
               </div>
-              <div className="flex items-center gap-2 text-gray-400 group-hover:text-primary transition-colors">
-                <span className="font-medium">상세보기</span>
-                <ChevronRight className="h-5 w-5" />
+              <div className="flex items-center gap-2 text-gray-400 transition-colors group-hover:text-primary">
+                <span className="hidden font-medium sm:inline">상세보기</span>
+                <ChevronRight className="w-5 h-5" />
               </div>
             </div>
           </button>
         ))}
 
         {resumes.length === 0 && (
-          <div className="bg-gray-50/50 rounded-xl p-8 text-center">
+          <div className="p-8 text-center bg-gray-50/50 rounded-xl">
             <Heading sizeOffset={2} className="text-gray-500">
               작성된 이력서가 없습니다.
               <br />
@@ -81,12 +86,12 @@ export default function ResumeList({ resumes }: ResumeListProps) {
       </div>
 
       {resumes.length > 0 && resumes.length < MAX_RESUMES && (
-        <div className="border-2 border-dashed border-gray-200 rounded-xl p-8">
+        <div className="p-8 border-2 border-gray-200 border-dashed rounded-xl">
           <button
             onClick={handleAddResume}
-            className="w-full flex flex-col items-center gap-2 text-gray-500 hover:text-primary transition-colors"
+            className="flex flex-col items-center w-full gap-2 text-gray-500 transition-colors hover:text-primary"
           >
-            <Plus className="h-8 w-8" />
+            <Plus className="w-8 h-8" />
             <Heading sizeOffset={2}>새 이력서 작성하기</Heading>
           </button>
         </div>

--- a/src/features/mypage/common/components/resume/ResumeList.tsx
+++ b/src/features/mypage/common/components/resume/ResumeList.tsx
@@ -31,18 +31,6 @@ export default function ResumeList({ resumes }: ResumeListProps) {
         <Heading sizeOffset={3} className="pl-3 font-bold text-gray-900">
           이력서 목록
         </Heading>
-        <button
-          onClick={handleAddResume}
-          className="flex items-center gap-2 px-4 py-2 font-medium text-white transition-all duration-200 rounded-lg bg-primary hover:bg-primary/90 hover:shadow-md"
-        >
-          <Plus className="w-5 h-5" />
-          <Heading sizeOffset={2} className="hidden sm:inline">
-            이력서 추가
-          </Heading>
-          <Heading sizeOffset={2} className="sm:hidden">
-            추가
-          </Heading>
-        </button>
       </div>
 
       <div className="grid gap-4">
@@ -57,13 +45,11 @@ export default function ResumeList({ resumes }: ResumeListProps) {
                 <Heading sizeOffset={2} className="font-semibold text-left text-gray-900">
                   {resume.resume_title}
                 </Heading>
-                <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                <div className="flex items-center gap-2">
                   <div className="inline-block px-3 py-1 font-medium rounded-full bg-primary/5 text-primary whitespace-nowrap">
                     {resume.job_category}
                   </div>
-                  <div className="mt-1.5 sm:mt-0 text-gray-500">
-                    최종 수정 : {formatDate(resume.updated_at)}
-                  </div>
+                  <div className="text-gray-500">최종 수정 : {formatDate(resume.updated_at)}</div>
                 </div>
               </div>
               <div className="flex items-center gap-2 text-gray-400 transition-colors group-hover:text-primary">

--- a/src/features/mypage/common/components/resume/ResumeList.tsx
+++ b/src/features/mypage/common/components/resume/ResumeList.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { useRouter } from "next/navigation";
+import { Plus, ChevronRight } from "lucide-react";
+import { Heading } from "@/components/ui/Heading";
+import { formatDate } from "@/utils/format";
+import type { Resume } from "@/types/resume";
+
+interface ResumeListProps {
+  resumes: Resume[];
+}
+
+export default function ResumeList({ resumes }: ResumeListProps) {
+  const router = useRouter();
+  const MAX_RESUMES = 5;
+
+  const handleResumeClick = (resumeId: string) => {
+    router.push(`/resume/${resumeId}`);
+  };
+
+  const handleAddResume = () => {
+    if (resumes.length >= MAX_RESUMES) {
+      alert("이력서는 최대 5개까지만 작성할 수 있습니다.");
+      return;
+    }
+    router.push("resume/create");
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between p-4 sm:p-6">
+        <Heading sizeOffset={3} className="font-bold text-gray-900">
+          이력서 목록
+        </Heading>
+        <button
+          onClick={handleAddResume}
+          className="bg-primary hover:bg-primary/90 text-white px-4 py-2 rounded-lg transition-all duration-200 font-medium flex items-center gap-2 hover:shadow-md"
+        >
+          <Plus className="h-5 w-5" />
+          <span>이력서 추가</span>
+        </button>
+      </div>
+
+      <div className="grid gap-4">
+        {resumes.map((resume) => (
+          <button
+            key={resume.resume_id}
+            onClick={() => handleResumeClick(resume.resume_id)}
+            className="w-full bg-white hover:bg-gray-50/80 border border-gray-100 rounded-xl p-4 transition-all duration-200 group hover:shadow-md"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-2">
+                <Heading sizeOffset={2} className="font-semibold text-gray-900 text-left">
+                  {resume.resume_title}
+                </Heading>
+                <div className="flex items-center gap-2">
+                  <span className="bg-primary/5 text-primary px-3 py-1 rounded-full font-medium">
+                    {resume.job_category}
+                  </span>
+                  <span className="text-gray-500 text-sm">
+                    최종 수정 : {formatDate(resume.updated_at)}
+                  </span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 text-gray-400 group-hover:text-primary transition-colors">
+                <span className="font-medium">상세보기</span>
+                <ChevronRight className="h-5 w-5" />
+              </div>
+            </div>
+          </button>
+        ))}
+
+        {resumes.length === 0 && (
+          <div className="bg-gray-50/50 rounded-xl p-8 text-center">
+            <Heading sizeOffset={2} className="text-gray-500">
+              작성된 이력서가 없습니다.
+              <br />
+              새로운 이력서를 작성해보세요!
+            </Heading>
+          </div>
+        )}
+      </div>
+
+      {resumes.length > 0 && resumes.length < MAX_RESUMES && (
+        <div className="border-2 border-dashed border-gray-200 rounded-xl p-8">
+          <button
+            onClick={handleAddResume}
+            className="w-full flex flex-col items-center gap-2 text-gray-500 hover:text-primary transition-colors"
+          >
+            <Plus className="h-8 w-8" />
+            <Heading sizeOffset={2}>새 이력서 작성하기</Heading>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -1,0 +1,10 @@
+export interface Resume {
+  resume_id: string;
+  user_id: string;
+  resume_title: string;
+  job_category: string;
+  education: string;
+  introduce: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,19 @@
+/**
+ * 날짜 문자열을 'YYYY.MM.DD' 형식으로 변환합니다.
+ * @param dateString - ISO 형식의 날짜 문자열 (예: "2024-03-01T09:00:00.000Z")
+ * @returns 'YYYY.MM.DD' 형식의 날짜 문자열
+ */
+export const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+};
+
+/**
+ * 생년월일을 'YYYY년 MM월 DD일' 형식으로 변환합니다.
+ * @param dateString - ISO 형식의 날짜 문자열
+ * @returns 'YYYY년 MM월 DD일' 형식의 날짜 문자열
+ */
+export const formatBirthDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return `${date.getFullYear()}년 ${String(date.getMonth() + 1).padStart(2, "0")}월 ${String(date.getDate()).padStart(2, "0")}일`;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #95

## 📝작업 내용

> 개인회원 마이페이지 이력서 탭에서 보여질 이력서 리스트 컴포넌트 만들어 구현하였습니다.
> 이력서 클릭 시, 이력서 상세보기로 이동되게 할 예정입니다.
> 새 이력서 작성하기 버튼은 이력서 5개미만일 경우에만 보여집니다.
> 프로필의 생년월일과 이력서 탭의 최종 수정일자에 대한 날짜 포맷팅 유틸리티 함수를 추가하여 적용하였습니다.

### 스크린샷 (선택)
<img width="536" alt="스크린샷 2025-04-22 오후 4 37 45" src="https://github.com/user-attachments/assets/e0982563-5a09-41a8-bd37-b3600e3fa348" />
<img width="523" alt="스크린샷 2025-04-22 오후 4 40 05" src="https://github.com/user-attachments/assets/fc505249-84f5-4599-96ed-90c79421d686" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
