### PR TITLE
feat/#89/[마이페이지] 개인회원 탭 리팩토링 및 회원 정보 수정 페이지 연결

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
 

--- a/src/features/auth-common/mock/auth.mock.ts
+++ b/src/features/auth-common/mock/auth.mock.ts
@@ -15,7 +15,7 @@ export const MOCK_COMPANY = {
 
 // 마이페이지 > 정보수정용 임시
 export const MOCK_USER1 = {
-  id: "1",
+  id: "123",
   name: "김오즈",
   birth: "1960-03-10",
   email: "kimoz@kakao.com",
@@ -29,7 +29,7 @@ export const MOCK_USER1 = {
 };
 
 export const MOCK_COMPANY1 = {
-  id: "1",
+  id: "123",
   companyName: "시니어내일",
   companyEmail: "company@senior.com",
   startDate: "2010-05-15",

--- a/src/features/mypage/common/components/myResume/ResumeList.tsx
+++ b/src/features/mypage/common/components/myResume/ResumeList.tsx
@@ -1,87 +1,97 @@
-import React from "react";
+import React, { createContext, useContext } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, ChevronRight } from "lucide-react";
 import { Heading } from "@/components/ui/Heading";
 import { formatDate } from "@/utils/format";
 import type { Resume } from "@/types/resume";
 
-interface ResumeCardProps {
-  resume: Resume;
-  onClick: (resumeId: string) => void;
-}
+const ResumeListContext = createContext<{ onCardClick: (resumeId: string) => void } | undefined>(
+  undefined,
+);
 
-const ResumeCard = ({ resume, onClick }: ResumeCardProps) => (
-  <button
-    onClick={() => onClick(resume.resume_id)}
-    className="w-full p-4 transition-all duration-200 bg-white border border-gray-100 hover:bg-gray-50/80 rounded-xl group hover:shadow-md"
-  >
-    <div className="flex items-center justify-between">
-      <div className="flex flex-col gap-2">
-        <Heading sizeOffset={2} className="font-semibold text-left text-gray-900">
-          {resume.resume_title}
-        </Heading>
-        <div className="flex items-center gap-2">
-          <div className="inline-block px-3 py-1 font-medium rounded-full bg-primary/5 text-primary whitespace-nowrap">
-            {resume.job_category}
+function Card({ resume }: { resume: Resume }) {
+  const context = useContext(ResumeListContext);
+  if (!context) throw new Error("ResumeList.Card는 ResumeList 내부에서만 사용해야 합니다.");
+  return (
+    <button
+      onClick={() => context.onCardClick(resume.resume_id)}
+      className="w-full p-4 transition-all duration-200 bg-white border border-gray-100 hover:bg-gray-50/80 rounded-xl group hover:shadow-md"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2">
+          <Heading sizeOffset={2} className="font-semibold text-left text-gray-900">
+            {resume.resume_title}
+          </Heading>
+          <div className="flex items-center gap-2">
+            <div className="inline-block px-3 py-1 font-medium rounded-full bg-primary/5 text-primary whitespace-nowrap">
+              {resume.job_category}
+            </div>
+            <div className="text-gray-500">최종 수정 : {formatDate(resume.updated_at)}</div>
           </div>
-          <div className="text-gray-500">최종 수정 : {formatDate(resume.updated_at)}</div>
+        </div>
+        <div className="flex items-center gap-2 text-gray-400 transition-colors group-hover:text-primary">
+          <span className="hidden font-medium sm:inline">상세보기</span>
+          <ChevronRight className="w-5 h-5" />
         </div>
       </div>
-      <div className="flex items-center gap-2 text-gray-400 transition-colors group-hover:text-primary">
-        <span className="hidden font-medium sm:inline">상세보기</span>
-        <ChevronRight className="w-5 h-5" />
-      </div>
-    </div>
-  </button>
-);
-
-interface AddResumeButtonProps {
-  onClick: () => void;
-}
-
-const AddResumeButton = ({ onClick }: AddResumeButtonProps) => (
-  <div className="p-4 border-2 border-gray-200 border-dashed rounded-xl">
-    <button
-      onClick={onClick}
-      className="flex flex-col items-center w-full gap-2 text-gray-500 transition-colors hover:text-primary"
-    >
-      <Plus className="w-8 h-8" />
-      <Heading sizeOffset={2}>새 이력서 작성하기</Heading>
     </button>
-  </div>
-);
-
-interface ResumeListProps {
-  resumes: Resume[];
+  );
 }
 
-export default function ResumeList({ resumes }: ResumeListProps) {
-  const router = useRouter();
-  const MAX_RESUMES = 5;
-
-  const handleResumeClick = (resumeId: string) => {
-    router.push(`/resume/${resumeId}`);
-  };
-
-  const handleAddResume = () => {
-    router.push("/resume/create");
-  };
-
+function AddButton({ children }: { children?: React.ReactNode }) {
+  const context = useContext(ResumeListContext);
+  if (!context) throw new Error("ResumeList.AddButton은 ResumeList 내부에서만 사용해야 합니다.");
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between pt-4 sm:pt-6">
-        <Heading sizeOffset={3} className="pl-3 font-bold text-gray-900">
-          이력서 목록
-        </Heading>
-      </div>
-
-      <div className="grid gap-4">
-        {resumes.map((resume) => (
-          <ResumeCard key={resume.resume_id} resume={resume} onClick={handleResumeClick} />
-        ))}
-      </div>
-
-      {resumes.length < MAX_RESUMES && <AddResumeButton onClick={handleAddResume} />}
+    <div className="p-4 border-2 border-gray-200 border-dashed rounded-xl">
+      <button
+        onClick={() => context.onCardClick("create")}
+        className="flex flex-col items-center w-full gap-2 text-gray-500 transition-colors hover:text-primary"
+      >
+        <Plus className="w-8 h-8" />
+        <Heading sizeOffset={2}>{children || "새 이력서 작성하기"}</Heading>
+      </button>
     </div>
   );
 }
+
+interface ResumeListProps {
+  resumes: Resume[];
+  children?: React.ReactNode;
+}
+
+function ResumeList({ resumes, children }: ResumeListProps) {
+  const router = useRouter();
+  const MAX_RESUMES = 5;
+
+  const handleCardClick = (resumeId: string) => {
+    if (resumeId === "create") {
+      router.push("/resume/create");
+    } else {
+      router.push(`/resume/${resumeId}`);
+    }
+  };
+
+  return (
+    <ResumeListContext.Provider value={{ onCardClick: handleCardClick }}>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between pt-4 sm:pt-6">
+          <Heading sizeOffset={3} className="pl-3 font-bold text-gray-900">
+            이력서 목록
+          </Heading>
+        </div>
+        <div className="grid gap-4">
+          {resumes.map((resume) => (
+            <ResumeList.Card key={resume.resume_id} resume={resume} />
+          ))}
+        </div>
+        {resumes.length < MAX_RESUMES && <ResumeList.AddButton />}
+        {children}
+      </div>
+    </ResumeListContext.Provider>
+  );
+}
+
+ResumeList.Card = Card;
+ResumeList.AddButton = AddButton;
+
+export default ResumeList;

--- a/src/features/mypage/common/components/profile/CompanyProfile.tsx
+++ b/src/features/mypage/common/components/profile/CompanyProfile.tsx
@@ -32,7 +32,7 @@ const CompanyProfile = () => {
 
   return (
     <div>
-      <ProfileCard role="company" title={company_name}>
+      <ProfileCard role="company" userId={companyProfileData.companyId} title={company_name}>
         {profileItems.map((item, idx) => (
           <ProfileCard.Item key={idx}>
             <ProfileCard.Label>{item.labels.join(" ")}</ProfileCard.Label>

--- a/src/features/mypage/common/components/profile/CompanyProfile.tsx
+++ b/src/features/mypage/common/components/profile/CompanyProfile.tsx
@@ -32,7 +32,14 @@ const CompanyProfile = () => {
 
   return (
     <div>
-      <ProfileCard role="company" title={company_name} items={profileItems} />
+      <ProfileCard role="company" title={company_name}>
+        {profileItems.map((item, idx) => (
+          <ProfileCard.Item key={idx}>
+            <ProfileCard.Label>{item.labels.join(" ")}</ProfileCard.Label>
+            <ProfileCard.Value isDescription={item.isDescription}>{item.value}</ProfileCard.Value>
+          </ProfileCard.Item>
+        ))}
+      </ProfileCard>
     </div>
   );
 };

--- a/src/features/mypage/common/components/profile/ProfileCard.tsx
+++ b/src/features/mypage/common/components/profile/ProfileCard.tsx
@@ -1,89 +1,103 @@
-import React from "react";
+import React, { createContext, useContext } from "react";
 import { useRouter } from "next/navigation";
 import { PenSquare } from "lucide-react";
 import { Heading } from "@/components/ui/Heading";
 import { UserRole } from "@/types/commonUser";
-import type { UserProfileItem } from "@/types/user";
-import type { CompanyProfileItem } from "@/types/company";
 
-type ProfileItem = UserProfileItem | CompanyProfileItem;
+interface ProfileCardContextType {
+  role: UserRole;
+}
+const ProfileCardContext = createContext<ProfileCardContextType | undefined>(undefined);
 
 interface ProfileCardProps {
   role: UserRole;
   title: string;
-  items: ProfileItem[];
+  children: React.ReactNode;
 }
 
-const ProfileLabel = ({
-  labels,
-  isEmployer = false,
-}: {
-  labels: string[];
-  isEmployer?: boolean;
-}) => {
+function ProfileCard({ role, title, children }: ProfileCardProps) {
+  const router = useRouter();
+  const handleEditClick = () => {
+    router.push(`/${role}/mypage/edit`);
+  };
+  const displayTitle = role === "user" ? `${title} 님` : title;
+  return (
+    <ProfileCardContext.Provider value={{ role }}>
+      <div className="w-[calc(100%-2rem)] sm:w-[36rem] md:w-[48rem] lg:w-[64rem] mx-auto bg-white rounded-2xl shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between p-4 border-b sm:p-6">
+          <Heading sizeOffset={3} className="font-bold text-gray-900 break-all">
+            {displayTitle}
+          </Heading>
+          <button
+            onClick={handleEditClick}
+            className="bg-primary hover:bg-primary/90 text-white px-2.5 sm:px-3 py-1 rounded-lg transition-colors duration-200 font-medium flex items-center gap-1.5 shadow-sm shrink-0 ml-3"
+          >
+            <PenSquare className="w-3.5 h-3.5" />
+            <Heading sizeOffset={1} className="hidden text-white sm:inline">
+              정보 수정
+            </Heading>
+            <Heading sizeOffset={1} className="text-white sm:hidden">
+              수정
+            </Heading>
+          </button>
+        </div>
+        <div className="p-3 m-3 break-words bg-gray-50/50 rounded-xl sm:m-4 md:m-5 sm:p-4 md:p-5">
+          <div className="space-y-5">{children}</div>
+        </div>
+      </div>
+    </ProfileCardContext.Provider>
+  );
+}
+
+function Item({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center px-4 py-3 transition-colors rounded-lg hover:bg-white/80 group">
+      {children}
+    </div>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  const context = useContext(ProfileCardContext);
+  const isEmployer = context?.role === "company";
   return (
     <span
       className={`${isEmployer ? "min-w-32 mr-8" : "w-32"} text-gray-500 font-medium flex flex-wrap items-center gap-1`}
     >
-      {labels.map((label, index) => (
-        <Heading key={index} sizeOffset={2} className="inline-block">
-          {label}
+      {Array.isArray(children) ? (
+        React.Children.map(children, (child, idx) => (
+          <Heading key={idx} sizeOffset={2} className="inline-block">
+            {child}
+          </Heading>
+        ))
+      ) : (
+        <Heading sizeOffset={2} className="inline-block">
+          {children}
         </Heading>
-      ))}
+      )}
     </span>
   );
-};
+}
 
-export default function ProfileCard({ role, title, items }: ProfileCardProps) {
-  const router = useRouter();
-
-  const handleEditClick = () => {
-    router.push(`/${role}/mypage/edit`);
-  };
-
-  const displayTitle = role === "user" ? `${title} 님` : title;
-
+function Value({
+  children,
+  isDescription = false,
+}: {
+  children: React.ReactNode;
+  isDescription?: boolean;
+}) {
   return (
-    <div className="w-[calc(100%-2rem)] sm:w-[36rem] md:w-[48rem] lg:w-[64rem] mx-auto bg-white rounded-2xl shadow-sm overflow-hidden">
-      <div className="flex items-center justify-between p-4 border-b sm:p-6">
-        <Heading sizeOffset={3} className="font-bold text-gray-900 break-all">
-          {displayTitle}
-        </Heading>
-        <button
-          onClick={handleEditClick}
-          className="bg-primary hover:bg-primary/90 text-white px-2.5 sm:px-3 py-1 rounded-lg transition-colors duration-200 font-medium flex items-center gap-1.5 shadow-sm shrink-0 ml-3"
-        >
-          <PenSquare className="w-3.5 h-3.5" />
-          <Heading sizeOffset={1} className="hidden text-white sm:inline">
-            정보 수정
-          </Heading>
-          <Heading sizeOffset={1} className="text-white sm:hidden">
-            수정
-          </Heading>
-        </button>
-      </div>
-      <div className="p-3 m-3 break-words bg-gray-50/50 rounded-xl sm:m-4 md:m-5 sm:p-4 md:p-5">
-        <div className="space-y-5">
-          {items.map((item, index) => (
-            <div
-              key={index}
-              className="flex items-center px-4 py-3 transition-colors rounded-lg hover:bg-white/80 group"
-            >
-              <ProfileLabel labels={item.labels} isEmployer={role === "company"} />
-              {item.isCustom ? (
-                <div className="flex-1">{item.value}</div>
-              ) : (
-                <Heading
-                  sizeOffset={2}
-                  className={`flex-1 text-gray-900 font-normal ${item.isDescription ? "whitespace-pre-wrap leading-relaxed" : ""}`}
-                >
-                  {item.value}
-                </Heading>
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
+    <Heading
+      sizeOffset={2}
+      className={`flex-1 text-gray-900 font-normal ${isDescription ? "whitespace-pre-wrap leading-relaxed" : ""}`}
+    >
+      {children}
+    </Heading>
   );
 }
+
+ProfileCard.Item = Item;
+ProfileCard.Label = Label;
+ProfileCard.Value = Value;
+
+export default ProfileCard;

--- a/src/features/mypage/common/components/profile/ProfileCard.tsx
+++ b/src/features/mypage/common/components/profile/ProfileCard.tsx
@@ -11,14 +11,15 @@ const ProfileCardContext = createContext<ProfileCardContextType | undefined>(und
 
 interface ProfileCardProps {
   role: UserRole;
+  userId: string;
   title: string;
   children: React.ReactNode;
 }
 
-function ProfileCard({ role, title, children }: ProfileCardProps) {
+function ProfileCard({ role, userId, title, children }: ProfileCardProps) {
   const router = useRouter();
   const handleEditClick = () => {
-    router.push(`/${role}/mypage/edit`);
+    router.push(`/${role}/mypage/${userId}/edit`);
   };
   const displayTitle = role === "user" ? `${title} 님` : title;
   return (

--- a/src/features/mypage/common/components/profile/UserProfile.tsx
+++ b/src/features/mypage/common/components/profile/UserProfile.tsx
@@ -105,7 +105,14 @@ export default function UserProfile() {
 
   return (
     <div>
-      <ProfileCard role="user" title={name} items={profileItems} />
+      <ProfileCard role="user" title={name}>
+        {profileItems.map((item, idx) => (
+          <ProfileCard.Item key={idx}>
+            <ProfileCard.Label>{item.labels[0]}</ProfileCard.Label>
+            <ProfileCard.Value isDescription={item.isCustom}>{item.value}</ProfileCard.Value>
+          </ProfileCard.Item>
+        ))}
+      </ProfileCard>
       <UserProfileTabs resumes={dummyResumes} />
     </div>
   );

--- a/src/features/mypage/common/components/profile/UserProfile.tsx
+++ b/src/features/mypage/common/components/profile/UserProfile.tsx
@@ -105,7 +105,7 @@ export default function UserProfile() {
 
   return (
     <div>
-      <ProfileCard role="user" title={name}>
+      <ProfileCard role="user" userId={userProfileData.userId} title={name}>
         {profileItems.map((item, idx) => (
           <ProfileCard.Item key={idx}>
             <ProfileCard.Label>{item.labels[0]}</ProfileCard.Label>

--- a/src/features/mypage/common/components/profile/UserProfileTabs.tsx
+++ b/src/features/mypage/common/components/profile/UserProfileTabs.tsx
@@ -5,25 +5,11 @@ import SavedJobList from "@/features/mypage/common/components/savedRecruit/Saved
 import type { Resume } from "@/types/resume";
 import { DUMMY_JOBS } from "@/features/mypage/common/data/dummy-jobs";
 import { TABS, TAB_STYLES, type TabType } from "@/features/mypage/common/constants/myPageTab";
-
-interface EmptyContentProps {
-  title: string;
-  message: string;
-}
-
-const EmptyContent = ({ title, message }: EmptyContentProps) => (
-  <div className="p-6 bg-white border border-gray-100 shadow-lg rounded-xl">
-    <Heading sizeOffset={2} className="mb-4 font-semibold text-gray-800">
-      {title}
-    </Heading>
-    <Heading sizeOffset={2} className="text-gray-500">
-      {message}
-    </Heading>
-  </div>
-);
+import AppliedJobList from "../applied/AppliedJobList";
+import { dummyAppliedJobs } from "../../mock/appliedJobs";
 
 interface UserProfileTabsProps {
-  resumes: Resume[] | null;
+  resumes?: Resume[];
 }
 
 export default function UserProfileTabs({ resumes }: UserProfileTabsProps) {

--- a/src/features/mypage/common/components/profile/UserProfileTabs.tsx
+++ b/src/features/mypage/common/components/profile/UserProfileTabs.tsx
@@ -3,7 +3,7 @@ import { Heading } from "@/components/ui/Heading";
 import ResumeList from "@/features/mypage/common/components/myResume/ResumeList";
 import SavedJobList from "@/features/mypage/common/components/savedRecruit/SavedRecruitList";
 import type { Resume } from "@/types/resume";
-import { DUMMY_JOBS } from "@/features/mypage/common/data/dummy-jobs";
+import { dummySavedJobs } from "@/features/mypage/common/mock/savedJobs";
 import { TABS, TAB_STYLES, type TabType } from "@/features/mypage/common/constants/myPageTab";
 import AppliedJobList from "../applied/AppliedJobList";
 import { dummyAppliedJobs } from "../../mock/appliedJobs";
@@ -15,7 +15,7 @@ interface UserProfileTabsProps {
 export default function UserProfileTabs({ resumes }: UserProfileTabsProps) {
   const [activeTab, setActiveTab] = useState<TabType>("resumes");
   const [currentPage, setCurrentPage] = useState(1);
-  const [SavedRecruit, setSavedRecruit] = useState(DUMMY_JOBS);
+  const [SavedRecruit, setSavedRecruit] = useState(dummySavedJobs);
 
   const handleToggleSave = (jobId: string) => {
     setSavedRecruit((prev) =>

--- a/src/features/mypage/common/mock/savedJobs.ts
+++ b/src/features/mypage/common/mock/savedJobs.ts
@@ -1,6 +1,6 @@
 import type { SavedRecruit } from "@/features/mypage/common/types/savedRecruit.types";
 
-export const DUMMY_JOBS: SavedRecruit[] = [
+export const dummySavedJobs: SavedRecruit[] = [
   {
     job_posting_id: "1",
     companyName: "스타벅스코리아",


### PR DESCRIPTION
## #️⃣연관된 이슈

> #102 #95 #80 #89

## 📝작업 내용
> 이력서리스트, 프로필 컴파운드 패턴으로 리팩토링
> 저장한 공고 더미데이터 컴포넌트명 및 폴더 위치 수정
> 마이페이지 프로필 정보수정 버튼 클릭 시, 회원 정보 수정페이지로 연결
> ci.yaml 버전 4로 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
